### PR TITLE
Generate certificates via helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,39 +18,7 @@ When applying a new scheme to a cluster, the application monitors the presence o
 ### Sequence diagram
 ![File location: docs/diagrams/mutatorSequenceDiagram.png](/docs/diagrams/mutatorSequenceDiagram.png?raw=true "Sequence diagram")
 ## :hammer: Installing components
-### Generate certificates
-Generate CA in /tmp :
-```
-cfssl gencert -initca ./certificates/tls/ca-csr.json | cfssljson -bare /tmp/ca
-```
 
-Generate private key and certificate for SSL connection:
-```
-cfssl gencert \
--ca=/tmp/ca.pem \
--ca-key=/tmp/ca-key.pem \
--config=./certificates/tls/ca-config.json \
--hostname="k8s-webhook-injector,k8s-webhook-injector.default.svc.cluster.local,k8s-webhook-injector.default.svc,localhost,127.0.0.1" \
--profile=default \
-./certificates/tls/ca-csr.json | cfssljson -bare /tmp/k8s-webhook-injector
-```
-
-Move your SSL key and certificate to the ssl directory:
-```
-mv /tmp/k8s-webhook-injector.pem ./certificates/ssl/k8s-webhook-injector.pem
-mv /tmp/k8s-webhook-injector-key.pem ./certificates/ssl/k8s-webhook-injector.key
-```
-
-Update configuration data in the helm-charts/mutator/values.yaml file with your key in the appropriate field `serverKey` and certificate in the appropriate field `serverCrt`:
-```
-cat ./certificates/ssl/k8s-webhook-injector.key | base64 | tr -d '\n'
-cat ./certificates/ssl/k8s-webhook-injector.pem | base64 | tr -d '\n'
-```
-
-Update field `caBundle` value in the helm-charts/mutator/values.yaml file with your base64 encoded CA certificate:
-```
-cat /tmp/ca.pem | base64 | tr -d '\n'
-```
 ### Demo-app
 Here is a demo application in which a busybox container in `patch-json-command.json` is injected to a pod with an nginx container
 

--- a/helm-charts/mutator/templates/configmap.yaml
+++ b/helm-charts/mutator/templates/configmap.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.confName }}
-  namespace: {{ .Release.Namespace }}
-data:
-  server.crt: {{ .Values.serverCrt }}
-  server.key: {{ .Values.serverKey }}

--- a/helm-charts/mutator/templates/webhook.yaml
+++ b/helm-charts/mutator/templates/webhook.yaml
@@ -1,3 +1,18 @@
+{{- $caPrefix := printf "%s-ca" .Release.Name }}
+{{- $ca := genCA $caPrefix 365 }}
+{{- $cn := .Release.Name }}
+{{- $altName := printf "%s.%s.svc" .Release.Name .Release.Namespace }}
+{{- $cert := genSignedCert $cn nil (list $altName) 365 $ca }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.confName }}
+  namespace: {{ .Release.Namespace }}
+data:
+  server.crt: {{ b64enc $cert.Cert }}
+  server.key: {{ b64enc $cert.Key }}
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -10,7 +25,7 @@ webhooks:
         name: {{ .Values.appName }}
         namespace: {{ .Release.Namespace }}
         path: {{ .Values.path }}
-      caBundle: {{ .Values.caBundle }}
+      caBundle: {{ b64enc $ca.Cert }}
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]

--- a/helm-charts/mutator/values.yaml
+++ b/helm-charts/mutator/values.yaml
@@ -15,18 +15,12 @@ replicaCount: 1 # number of replicas
 
 confName: ssl-k8s-webhook-injector # configuration name
 
-# TODO should be removed after implementation of helm based certificate generation
-serverCrt: "your certificate" # ssl key
-serverKey: "your key" # ssl certificate
-
 # cert and key file names referenced to corresponding config map keys with certificate and key
 serverCrtFile: server.crt
 serverKeyFile: server.key
 
 # Values for mutator-configuration
 sideCarConfig: /etc/sidecar/config/monitor-sidecar-config.yaml
-
-caBundle: "your CA certificate" # caBundle value
 
 path: "/mutate"
 


### PR DESCRIPTION
Changed certificate generating functionality in favor of generating via helm charts.

Tested with `helm lint` and `helm template`.

Removed certificate generation section from README.md as it's handled via helm and manual generation isn't actual anymore.